### PR TITLE
Fix supervisor environment variable syntax

### DIFF
--- a/etc/supervisord.conf
+++ b/etc/supervisord.conf
@@ -18,7 +18,7 @@ user=nginx
 priority=3
 
 [program:fetch_diff]
-command=/app/bin/fetch_osc.sh auto %(OVERPASS_DIFF_URL)s /db/diffs
+command=/app/bin/fetch_osc.sh auto %(ENV_OVERPASS_DIFF_URL)s /db/diffs
 user=overpass
 redirect_stderr=true
 priority=5


### PR DESCRIPTION
With the latest Docker image, supervisord errors out with:

```
Error: Format string '/app/bin/fetch_osc.sh auto %(OVERPASS_DIFF_URL)s /db/diffs' for 'program:fetch_diff.command' contains names ('OVERPASS_DIFF_URL') which cannot be expanded. Available names: ENV_HOME, ENV_HOSTNAME, ENV_NGINX_VERSION, ENV_NJS_VERSION, ENV_OVERPASS_DIFF_URL, ENV_OVERPASS_META, ENV_OVERPASS_MODE, ENV_PATH, ENV_PWD, ENV_SHLVL, ENV_TERM, group_name, here, host_node_name, process_num, program_name in section 'program:fetch_diff' (file: '/etc/supervisor/conf.d/supervisord.conf')
For help, use /usr/bin/supervisord -h
```

This PR fixes that.