### PR TITLE
Install 'ca-certificates' Debian package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
         autoconf \
         automake \
+        ca-certificates \
         expat \
         libexpat1-dev \
         g++ \


### PR DESCRIPTION
## In this PR
Prevents certificate errors when using OSM mirrors listed on https://wiki.openstreetmap.org/wiki/Planet.osm#Planet.osm_mirrors which use https.

## Example:
For URL https://download.geofabrik.de/north-america-latest.osm.bz2 I got the following error before this change:

```
get: /north-america-latest.osm.bz2: Fatal error: Certificate verification: Not trusted (E6:A3:B4:5B:06:2D:50:9B:33:82:28:2D:19:6E:FE:97:D5:95:6C:CB)
```